### PR TITLE
Trace for Vs code problem matcher

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ All of these are optional.
 | `-D watch.port=(integer)`   | use this port for the completion server                                 |
 | `-D watch.connect`          | connect to a running completion server (use with `watch.port`)          |
 | `-D watch.exclude=(string)` | exclude this path from the watcher (can be repeated for multiple paths) |
+| `-D watch.verbose`          | extra log before and after every build                                  |
 
 ### Example
 

--- a/src/watch/Watch.hx
+++ b/src/watch/Watch.hx
@@ -264,12 +264,14 @@ function register() {
               }
               building = true;
               final start = Sys.time();
+              Sys.println('\x1b[32m> Build started');
               server.build(config, (hasError: Bool) -> {
                 building = false;
                 final duration = (Sys.time() - start) * 1000;
                 closeRun(() -> {
                   closeRun = cb -> cb();
                   timer.close(() -> {
+                    Sys.println('\x1b[32m> Build finished');
                     if (hasError) {
                       Sys.println('\x1b[90m> Found errors\x1b[39m');
                     } else { 

--- a/src/watch/Watch.hx
+++ b/src/watch/Watch.hx
@@ -264,14 +264,18 @@ function register() {
               }
               building = true;
               final start = Sys.time();
-              Sys.println('\x1b[32m> Build started');
+              if (Context.defined('watch.verbose'))
+                Sys.println('\x1b[32m> Build started\x1b[39m');
               server.build(config, (hasError: Bool) -> {
                 building = false;
                 final duration = (Sys.time() - start) * 1000;
                 closeRun(() -> {
                   closeRun = cb -> cb();
                   timer.close(() -> {
-                    Sys.println('\x1b[32m> Build finished');
+                    if (Context.defined('watch.verbose')) {
+                      final status = if (hasError) 31 else 32;
+                      Sys.println('\x1b[${status}m> Build finished\x1b[39m');
+                    }
                     if (hasError) {
                       Sys.println('\x1b[90m> Found errors\x1b[39m');
                     } else { 


### PR DESCRIPTION
I've added 2 Sys.println to easely keep track of each build independently, so we can add "Build started" and "Build finished" to Vs code problem matcher.