### PR TITLE
Build child process tree in windows using `wmic`

### DIFF
--- a/src/watch/Watch.hx
+++ b/src/watch/Watch.hx
@@ -220,7 +220,7 @@ function killAll(tree: Map<Int, Array<Int>>, callback: (error: Option<String>) -
       tree.get(pid).iter(pidpid -> {
         final isKilled = killed.get(pidpid) ?? false;
         if (!isKilled) {
-          switch Process.killPid(pidpid, SIGKILL) {
+          switch Process.killPid(pidpid, SIGTERM) {
             case Ok(_):
               killed.set(pidpid, true);
             case Error(e):
@@ -228,7 +228,7 @@ function killAll(tree: Map<Int, Array<Int>>, callback: (error: Option<String>) -
         }
       });
       if (!(killed.get(pid) ?? false)) {
-        switch Process.killPid(pid, SIGKILL) {
+        switch Process.killPid(pid, SIGTERM) {
           case Ok(_):
             killed.set(pid, true);
           case Error(e):


### PR DESCRIPTION
On windows it would only find the process for the `cmd` process, and in some cases it would not kill its spawned process. This PR uses `wmic` to find its child PIDs and kill them too.

Also use SIGTERM instead of SIGKILL when terminating running processes. This gives the running application room to exit gracefully instead of being forcefully closed.